### PR TITLE
Arena packet fixes

### DIFF
--- a/xml/net/server/protocol.xml
+++ b/xml/net/server/protocol.xml
@@ -2377,7 +2377,6 @@
             <field name="killer_name" type="string"/>
             <break/>
             <field name="victim_name" type="string"/>
-            <break/>
         </chunked>
     </packet>
 
@@ -2391,7 +2390,6 @@
             <field name="killer_name" type="string"/>
             <break/>
             <field name="victim_name" type="string"/>
-            <break/>
         </chunked>
     </packet>
 


### PR DESCRIPTION
~~Changes kill count to char and~~ removes extra break bytes

edit: Client does try to read an int here. Server just happens to send a char and it works because of packet chunking