### PR TITLE
Change `Direction` to `direction` in Walk_Player packet

### DIFF
--- a/xml/net/server/protocol.xml
+++ b/xml/net/server/protocol.xml
@@ -1442,7 +1442,7 @@
     <packet family="Walk" action="Player">
         <comment>Nearby player has walked</comment>
         <field name="player_id" type="short"/>
-        <field name="Direction" type="Direction"/>
+        <field name="direction" type="Direction"/>
         <field name="coords" type="Coords"/>
     </packet>
 


### PR DESCRIPTION
Noticed this during codegen in rust

<img width="581" alt="image" src="https://github.com/Cirras/eo-protocol/assets/3664832/059785e5-b988-475a-aff0-3831ca0dbaad">
