### PR TITLE
Change npcs_count from `short` to `char` in `NPC_AGREE` packet

### DIFF
--- a/xml/net/server/protocol.xml
+++ b/xml/net/server/protocol.xml
@@ -1435,7 +1435,7 @@
 
     <packet family="Npc" action="Agree">
         <comment>Reply to request for information about nearby NPCs</comment>
-        <length name="npcs_count" type="short"/>
+        <length name="npcs_count" type="char"/>
         <array name="npcs" type="NpcMapInfo" length="npcs_count"/>
     </packet>
 


### PR DESCRIPTION
This is a protocol correctness error. GameServer uses a `char` for this field instead of a `short`. See: https://github.com/sorokya/eo_protocol/commit/816f7877a26f1e71b8af4085ef7edf92526a1382