### PR TITLE
Change some NPC reply fields to optional and add documentation

### DIFF
--- a/xml/net/server/protocol.xml
+++ b/xml/net/server/protocol.xml
@@ -2276,38 +2276,58 @@
         <field name="npc_index" type="short"/>
         <field name="damage" type="three"/>
         <field name="hp_percentage" type="short"/>
-        <field name="caster_tp" type="short"/>
-        <field name="kill_steal_protection" type="NpcKillStealProtectionState" optional="true"/>
+        <field name="caster_tp" type="short" optional="true">
+            <comment>This field should be sent to the attacker, but not nearby players</comment>
+        </field>
+        <field name="kill_steal_protection" type="NpcKillStealProtectionState" optional="true">
+            <comment>This field should be sent to the attacker, but not nearby players</comment>
+        </field>
     </packet>
 
     <packet family="Npc" action="Spec">
         <comment>Nearby NPC killed by player</comment>
         <field name="npc_killed_data" type="NpcKilledData"/>
-        <field name="experience" type="int" optional="true"/>
+        <field name="experience" type="int" optional="true">
+            <comment>This field should be sent to the killer, but not nearby players</comment>
+        </field>
     </packet>
 
     <packet family="Npc" action="Accept">
-        <comment>Nearby NPC killed by player and you leveled up</comment>
+        <comment>Nearby NPC killed and killer leveled up</comment>
         <field name="npc_killed_data" type="NpcKilledData"/>
-        <field name="experience" type="int"/>
-        <field name="level_up" type="LevelUpStats"/>
+        <field name="experience" type="int" optional="true">
+            <comment>This field should be sent to the killer, but not nearby players</comment>
+        </field>
+        <field name="level_up" type="LevelUpStats" optional="true">
+            <comment>This field should be sent to the killer if they leveled up, but not nearby players</comment>
+        </field>
     </packet>
 
     <packet family="Cast" action="Spec">
         <comment>Nearby NPC killed by player spell</comment>
         <field name="spell_id" type="short"/>
         <field name="npc_killed_data" type="NpcKilledData"/>
-        <field name="caster_tp" type="short"/>
-        <field name="experience" type="int" optional="true"/>
+        <field name="caster_tp" type="short" optional="true">
+            <comment>This field should be sent to the killer, but not nearby players</comment>
+        </field>
+        <field name="experience" type="int" optional="true">
+            <comment>This field should be sent to the killer, but not nearby players</comment>
+        </field>
     </packet>
 
     <packet family="Cast" action="Accept">
-        <comment>Nearby NPC killed by player spell and you leveled up</comment>
+        <comment>Nearby NPC killed by player spell and killer leveled up</comment>
         <field name="spell_id" type="short"/>
         <field name="npc_killed_data" type="NpcKilledData"/>
-        <field name="caster_tp" type="short"/>
-        <field name="experience" type="int"/>
-        <field name="level_up" type="LevelUpStats"/>
+        <field name="caster_tp" type="short" optional="true">
+            <comment>This field should be sent to the killer, but not nearby players</comment>
+        </field>
+        <field name="experience" type="int" optional="true">
+            <comment>This field should be sent to the killer, but not nearby players</comment>
+        </field>
+        <field name="level_up" type="LevelUpStats" optional="true">
+            <comment>This field should be sent to the killer if they leveled up, but not nearby players</comment>
+        </field>
     </packet>
 
     <packet family="Npc" action="Junk">


### PR DESCRIPTION

# GameServer kill mob & both members level up

```
11:07:22.402 [S->C] Recover_TargetGroup
64 FE 85 FE 88 FE 61 FE 44 FE

11:07:22.403 [S->C] Party_TargetGroup
CC 2 49 CE 8 FE 22

11:07:22.542 [S->C] Party_TargetGroup
CC 2 49 CE 8 FE 22

11:07:22.542 [S->C] Cast_Accept
6 FE F4 2 1 3 FE 1 FE 1 FE A 6 1 FE FE FE B FE FE

11:07:22.543 [S->C] Cast_Accept
6 FE F4 2 1 3 FE 1 FE 1 FE A 6 1 FE FE FE B FE FE 53 FE AE 78 4B FE 21 61 FE 81 FE F2 FE 5C FE 4A FE
```

1. Party experience is granted (Recover_TargetGroup)
	- Only includes non-killer exp gains
2. Party level updates are shared with party (Party_TargetGroup)
3. NPC Kill sent to nearby
	- If you are the killer contains ([tp if spell], exp, and level up stats)