### PR TITLE
Address various inconsistencies between the protocol spec and GameServer data

### DIFF
--- a/xml/net/client/protocol.xml
+++ b/xml/net/client/protocol.xml
@@ -162,7 +162,13 @@
     <packet family="Character" action="Remove">
         <comment>Confirm deleting character from an account</comment>
         <field name="session_id" type="short"/>
-        <field name="character_id" type="int"/>
+        <field name="character_id" type="int">
+            <comment>
+                The official client sends a short, which gets written as a variable-sized integer
+                (2-4 bytes) due to a quirk of the official encoding routine.
+                However, the official server expects an int.
+            </comment>
+        </field>
     </packet>
 
     <packet family="Login" action="Request">

--- a/xml/net/client/protocol.xml
+++ b/xml/net/client/protocol.xml
@@ -898,6 +898,9 @@
         <field name="npc_index" type="short"/>
         <field name="reply_type" type="DialogReply"/>
         <switch field="reply_type">
+            <case value="Ok">
+                <field type="char">0</field>
+            </case>
             <case value="Link">
                 <field name="action" type="char"/>
             </case>

--- a/xml/net/server/protocol.xml
+++ b/xml/net/server/protocol.xml
@@ -2473,6 +2473,7 @@
         <comment>HP/TP update</comment>
         <field name="hp" type="short"/>
         <field name="tp" type="short"/>
+        <field type="short">0</field>
     </packet>
 
     <packet family="Recover" action="Agree">

--- a/xml/net/server/protocol.xml
+++ b/xml/net/server/protocol.xml
@@ -1007,7 +1007,7 @@
                 <field type="string">NO</field>
             </case>
             <case value="Changed">
-                <field type="string">NO</field>
+                <field type="string">OK</field>
             </case>
             <case value="RequestDenied">
                 <field type="string">NO</field>

--- a/xml/net/server/protocol.xml
+++ b/xml/net/server/protocol.xml
@@ -1604,7 +1604,6 @@
             <array name="trade_items" type="ShopTradeItem"/>
             <break/>
             <array name="craft_items" type="ShopCraftItem"/>
-            <break/>
         </chunked>
     </packet>
 

--- a/xml/net/server/protocol.xml
+++ b/xml/net/server/protocol.xml
@@ -1228,6 +1228,7 @@
             <break/>
             <field name="usage" type="int"/>
             <break/>
+            <field name="gold_bank" type="int"/>
             <break/>
             <field name="exp" type="int"/>
             <field name="level" type="char"/>

--- a/xml/net/server/protocol.xml
+++ b/xml/net/server/protocol.xml
@@ -1902,8 +1902,12 @@
 
     <packet family="Door" action="Open">
         <comment>Nearby door opening</comment>
-        <field name="coords" type="Coords"/>
-        <field type="char">0</field>
+        <field name="coords" type="Coords">
+            <comment>
+                The official server erroneously encodes the Y coordinate as a short.
+                The official client reads each coordinate as a char.
+            </comment>
+        </field>
     </packet>
 
     <packet family="Door" action="Close">


### PR DESCRIPTION
See individual commits for details. The following packets are changed:
- Character_Remove (client)
- Quest_Accept (client)
- Account_Reply (server)
- AdminInteract_Tell (server)
- Recover_Player (server)
- Shop_Open (server)

The software used for testing these packets was the latest available v28 client and the GameServer software hosted at `moffat.io:8079` (running on a Windows XP VM). 