### PR TITLE
Fix TradeItemData order in `TRADE_REPLY` and `TRADE_ADMIN` packets

### DIFF
--- a/xml/net/server/protocol.xml
+++ b/xml/net/server/protocol.xml
@@ -744,11 +744,8 @@
     <struct name="TradeItemData">
         <comment>Trade window item data</comment>
         <chunked>
-            <field name="partner_player_id" type="short"/>
-            <array name="partner_items" type="Item"/>
-            <break/>
-            <field name="your_player_id" type="short"/>
-            <array name="your_items" type="Item"/>
+            <field name="player_id" type="short"/>
+            <array name="items" type="Item"/>
             <break/>
         </chunked>
     </struct>
@@ -2242,17 +2239,17 @@
 
     <packet family="Trade" action="Reply">
         <comment>Trade updated (items changed)</comment>
-        <field name="trade_data" type="TradeItemData"/>
+        <array name="trade_data" type="TradeItemData" length="2"/>
     </packet>
 
     <packet family="Trade" action="Admin">
         <comment>Trade updated (items changed while trade was accepted)</comment>
-        <field name="trade_data" type="TradeItemData"/>
+        <array name="trade_data" type="TradeItemData" length="2"/>
     </packet>
 
     <packet family="Trade" action="Use">
         <comment>Trade completed</comment>
-        <field name="trade_data" type="TradeItemData"/>
+        <array name="trade_data" type="TradeItemData" length="2"/>
     </packet>
 
     <packet family="Trade" action="Spec">


### PR DESCRIPTION
Inside of the TRADE_REPLY and TRADE_ADMIN packets your id/items are added before the partner id/items (see https://github.com/eoserv/eoserv/blob/7025373affd41edeeee141fc83a1d453767c3688/src/handlers/Trade.cpp#L242). Inside of the TRADE_USE packet this is reversed (see https://github.com/eoserv/eoserv/blob/7025373affd41edeeee141fc83a1d453767c3688/src/handlers/Trade.cpp#L143).
